### PR TITLE
Changed array_merge to array_merge_recursive

### DIFF
--- a/craft/config/general.php
+++ b/craft/config/general.php
@@ -23,7 +23,7 @@ $customGeneralConfig = array(
 // Merge any environment-specific custom config settings 
 if (is_array($customEnvironmentConfig = @include(CRAFT_CONFIG_PATH . ENV . '/general.php')))
 {
-	$customGeneralConfig = array_merge($customGeneralConfig, $customEnvironmentConfig);
+	$customGeneralConfig = array_merge_recursive($customGeneralConfig, $customEnvironmentConfig);
 }
 
 return $customGeneralConfig;


### PR DESCRIPTION
Changing array_merge to array_merge_recursive in general.php allows users to use arrays like environmentVariables in both general and environment-specific config files
