### PR TITLE
Add option to optionally force "www." to beginning of urls

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -240,6 +240,21 @@ FileETag None
 
 
 # ----------------------------------------------------------------------
+# Force "www." to beginning of URLs
+# http://stackoverflow.com/questions/4916222/htaccess-how-to-force-www-in-a-generic-way
+# ----------------------------------------------------------------------
+
+# If using this, make sure the "Remove www. from beginning of URLS" block is commented out
+
+# <IfModule mod_rewrite.c>
+#     RewriteCond %{HTTP_HOST} !^$
+#     RewriteCond %{HTTP_HOST} !^www\. [NC]
+#     RewriteCond %{HTTPS}s ^on(s)|
+#     RewriteRule ^ http%1://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+# </IfModule>
+
+
+# ----------------------------------------------------------------------
 # Force https:// for the Control Panel
 # Exclude our local and  development environment if we don't have ssl setup there
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Sometimes it is preferable to have "www." at beginning of urls. This commit adds a commented out block that would allow for that.
