### PR TITLE
Add a 'webPath' variable.

### DIFF
--- a/craft/config/general.php
+++ b/craft/config/general.php
@@ -34,8 +34,9 @@ $customConfig = array(
     // We can use these variables in the URL and Path settings within
     // the Craft Control Panel.  i.e. siteUrl => {siteUrl}, basePath => {basePath} 
   	'environmentVariables' => array(
-  	  'siteUrl'  => SITE_URL,
-      'basePath' => BASEPATH
+		'siteUrl'  => SITE_URL,
+		'basePath' => BASEPATH,
+		'webPath' => CRAFT_WEB_PATH
   	),
 
     // Triggers

--- a/public/index.php
+++ b/public/index.php
@@ -18,6 +18,8 @@ switch ($_SERVER['SERVER_NAME']) {
 		break;
 }
 
+define('CRAFT_WEB_PATH', $_SERVER["DOCUMENT_ROOT"]. '/');
+
 // Do not edit below this line
 $path = rtrim($craftPath, '/').'/app/index.php';
 


### PR DESCRIPTION
This edit goes along with another I'm submitting in the "public/index.php" file. I've done this so my Asset paths can point to the web root easily. My "public" folder isn't always named "public" between servers and this let's the value be set automatically with the user of {webPath} in Assets>Sources, like "{webPath}images/projects/".
